### PR TITLE
reset slide menu bar when the ios app got closed in the middle of sli…

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,7 @@ Slideout.prototype._initTouchEvents = function() {
   this._onTouchCancelFn = function() {
     self._moved = false;
     self._opening = false;
+    self._preventOpen = false;
   };
 
   this.panel.addEventListener('touchcancel', this._onTouchCancelFn);
@@ -244,7 +245,13 @@ Slideout.prototype._initTouchEvents = function() {
     if (self._moved) {
       self.emit('translateend');
       (self._opening && Math.abs(self._currentOffsetX) > self._tolerance) ? self.open() : self.close();
+    } else if (self._currentOffsetX !== 0){
+      // Reset the slide when it's stuck and lost track of _currentOffsetX
+      self._opened = true;
+      self._startOffsetX = 0;
+      self.close();
     }
+    self._preventOpen = false;
     self._moved = false;
   };
 


### PR DESCRIPTION
###Description

When closing the app while sliding out the panel, the `_currentOffsetX` gets stuck in the previous setting but `_moved` gets set to `false` so it's an able to move the panel.
